### PR TITLE
docs: add note about liveview from npm conflict with sdk 8

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -336,6 +336,8 @@ It allows you to quickly test your app on multiple devices at the same time and 
 
 ### Liveview
 
+**Note:** As of SDK 8.0.0 Liveview is now part of the SDK, it is not recommended or supported to install Liveview via npm as this will conflict with the SDK version.
+
 Liveview is available as a npm package now.
 
 * `npm install -g liveview`


### PR DESCRIPTION
As of SDK 8 we're now shipping liveview with the SDK, using the liveview npm package causes conflicts with the liveview that resides in the SDK (the two liveview servers fight each others for the port.

This change adds a note recommending not to install liveview manually, I've left the section in as I can see it being of value for users not on 8